### PR TITLE
feat: Add `verified_domain`s  to `ProjectData`

### DIFF
--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -17,10 +17,11 @@ pub struct ProjectData {
     pub name: String,
     pub push_url: Option<String>,
     pub keys: Vec<ProjectKey>,
-    pub homepage: Option<String>,
-    pub is_dns_verified: bool,
     pub is_enabled: bool,
     pub allowed_origins: Vec<String>,
+
+    #[serde(default)]
+    pub verified_domain: Option<String>,
 }
 
 impl ProjectData {

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -17,6 +17,8 @@ pub struct ProjectData {
     pub name: String,
     pub push_url: Option<String>,
     pub keys: Vec<ProjectKey>,
+    pub homepage: Option<String>,
+    pub is_dns_verified: bool,
     pub is_enabled: bool,
     pub allowed_origins: Vec<String>,
 }

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -19,8 +19,6 @@ pub struct ProjectData {
     pub keys: Vec<ProjectKey>,
     pub is_enabled: bool,
     pub allowed_origins: Vec<String>,
-
-    #[serde(default)]
     pub verified_domains: Vec<String>,
 }
 

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -21,7 +21,7 @@ pub struct ProjectData {
     pub allowed_origins: Vec<String>,
 
     #[serde(default)]
-    pub verified_domain: Option<String>,
+    pub verified_domains: Vec<String>,
 }
 
 impl ProjectData {


### PR DESCRIPTION
# Description

Requires WalletConnect/explorer-api/issues/99 to be merged and deployed, but won't fail for existing deployments because of `#[serde(default)]`

Related to WalletConnect/bouncer/issues/2

## How Has This Been Tested?

`bouncer` integration tests

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
