### PR TITLE
feat: support `creator` in project data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+.idea

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -14,6 +14,7 @@ pub struct ProjectKey {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectData {
     pub uuid: String,
+    pub creator: String,
     pub name: String,
     pub push_url: Option<String>,
     pub keys: Vec<ProjectKey>,


### PR DESCRIPTION
# Description
Supports the `creator` field in `project_data`, prerequisite: https://github.com/WalletConnect/explorer-api/pull/106

## How Has This Been Tested?
Integrating with Echo Server

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
