### PR TITLE
fix: handle invalid projectId

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ once_cell = "1.15"
 regex = "1.6"
 reqwest = { version = "0.11", features = ["json"] }
 thiserror = "1.0"
+
+[dev-dependencies]
+tokio = { version = "1.29.1", features = ["full"] }
+wiremock = "0.5.19"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # Cerberus
+
+## Dev loop
+
+```bash
+just amigood
+```

--- a/justfile
+++ b/justfile
@@ -85,6 +85,8 @@ commit-check:
     echo '    ^^^ To install `cargo install --locked cocogitto`, see https://github.com/cocogitto/cocogitto for details'
   fi
 
+amigood: lint test test-all
+
 # Build project documentation
 _build-docs $open="":
   @echo "==> Building project documentation @$JUST_ROOT/target/doc"

--- a/justfile
+++ b/justfile
@@ -1,0 +1,91 @@
+binary-crate            := "."
+
+export JUST_ROOT        := justfile_directory()
+
+# Default to listing recipes
+_default:
+  @just --list --list-prefix '  > '
+
+# Open project documentation in your local browser
+open-docs: (_build-docs "open")
+  @echo '==> Opening documentation in system browser'
+
+# Fast check project for errors
+check:
+  @echo '==> Checking project for compile errors'
+  cargo check --workspace
+
+# Build service for development
+build:
+  @echo '==> Building project'
+  cargo build
+
+# Build project documentation
+build-docs: (_build-docs "")
+
+# Run project test suite, skipping storage tests
+test:
+  @echo '==> Testing project (default)'
+  cargo test --workspace
+
+# Run project test suite, testing all features
+test-all:
+  @echo '==> Testing project (all features)'
+  cargo test --workspace --all-features
+
+# Run test from project documentation
+test-doc:
+  @echo '==> Testing project docs'
+  cargo test --workspace --doc
+
+# Clean build artifacts
+clean:
+  @echo '==> Cleaning project target/*'
+  cargo clean
+
+# Lint the project for any quality issues
+lint: check fmt clippy commit-check
+
+# Run project linter
+clippy:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v cargo-clippy >/dev/null; then
+    echo '==> Running clippy'
+    cargo clippy --workspace --all-features --tests -- -D clippy::all -W clippy::style
+  else
+    echo '==> clippy not found in PATH, skipping'
+    echo '    ^^^^^^ To install `rustup component add clippy`, see https://github.com/rust-lang/rust-clippy for details'
+  fi
+
+# Run code formatting check
+fmt:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v cargo-fmt >/dev/null; then
+    echo '==> Running rustfmt'
+    cargo +nightly fmt --all
+  else
+    echo '==> rustfmt not found in PATH, skipping'
+    echo '    ^^^^^^ To install `rustup component add rustfmt`, see https://github.com/rust-lang/rustfmt for details'
+  fi
+
+# Run commit checker
+commit-check:
+  #!/bin/bash
+  set -euo pipefail
+
+  if command -v cog >/dev/null; then
+    echo '==> Running cog check'
+    cog check --from-latest-tag
+  else
+    echo '==> cog not found in PATH, skipping'
+    echo '    ^^^ To install `cargo install --locked cocogitto`, see https://github.com/cocogitto/cocogitto for details'
+  fi
+
+# Build project documentation
+_build-docs $open="":
+  @echo "==> Building project documentation @$JUST_ROOT/target/doc"
+  @cargo doc --all-features --workspace --no-deps ${open:+--open}

--- a/src/registry/client.rs
+++ b/src/registry/client.rs
@@ -116,13 +116,13 @@ fn is_hex_string(string: &str) -> bool {
 }
 
 async fn parse_http_response(resp: reqwest::Response) -> RegistryResult<Option<ProjectData>> {
-    match resp.status() {
+    let status = resp.status();
+    match status {
         code if code.is_success() => Ok(Some(resp.json().await?)),
         StatusCode::FORBIDDEN => Err(RegistryError::Config(INVALID_TOKEN_ERROR)),
         StatusCode::NOT_FOUND => Ok(None),
         _ => Err(RegistryError::Response(format!(
-            "status={} body={:?}",
-            resp.status(),
+            "status={status} body={:?}",
             resp.text().await
         ))),
     }


### PR DESCRIPTION
# Description

Handles the project ID having invalid format instead of treating it as a error.

This helps eliminate 500 errors in the RPC proxy: https://walletconnect.slack.com/archives/C03SHRNSCBS/p1690466632022249

Resolves #19

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
