### PR TITLE
feat: project qouta

### DIFF
--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -23,6 +23,15 @@ pub struct ProjectData {
     pub is_rate_limited: bool,
     pub allowed_origins: Vec<String>,
     pub verified_domains: Vec<String>,
+    pub quota: Quota,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct Quota {
+    pub max: u64,
+    pub current: u64,
+    pub is_valid: bool,
 }
 
 impl ProjectData {

--- a/src/registry/client.rs
+++ b/src/registry/client.rs
@@ -132,6 +132,7 @@ async fn parse_http_response(resp: reqwest::Response) -> RegistryResult<Option<P
 mod test {
     use {
         super::*,
+        crate::project,
         wiremock::{
             http::Method,
             matchers::{method, path},
@@ -153,6 +154,11 @@ mod test {
             is_rate_limited: false,
             allowed_origins: vec![],
             verified_domains: vec![],
+            quota: project::Quota {
+                max: 42,
+                current: 1,
+                is_valid: true,
+            },
         }
     }
 


### PR DESCRIPTION
# Description

Exposes `qouta` information returned by the `/internal` API

## How Has This Been Tested?

`bouncer`'s integration tests

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
