### PR TITLE
feat: proper bundle ID and package name validation

### DIFF
--- a/src/project/types/origin.rs
+++ b/src/project/types/origin.rs
@@ -1,12 +1,7 @@
 use {
-    bitflags::bitflags,
     once_cell::sync::Lazy,
     regex::Regex,
-    std::{
-        fmt::Display,
-        iter::{zip, Rev, Zip},
-        slice::Iter,
-    },
+    std::{fmt::Display, iter::zip},
     thiserror::Error as ThisError,
 };
 
@@ -15,25 +10,10 @@ use {
 static ORIGIN_PARSER_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^(([^:]+)://)?([^:/]+)(:([\d]+))?").unwrap());
 
-bitflags! {
-    /// Values used to configure the origin matching behavior.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-    pub struct MatchingPolicy: u32 {
-        const CheckScheme        = 0b000001;
-        const CheckPort          = 0b000010;
-
-        const CheckAll           = Self::CheckScheme.bits() | Self::CheckPort.bits();
-
-        const AllowBundleID      = 0b001000;
-        const AllowEmptyScheme   = 0b010000;
-        const AllowEmptyPort     = 0b100000;
-        }
-}
-
-impl Default for MatchingPolicy {
-    fn default() -> Self {
-        Self::CheckAll | Self::AllowEmptyScheme
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MatchDirection {
+    Forward,
+    Reverse,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,88 +28,47 @@ const WILDCARD: &str = "*";
 
 impl<'a> Origin<'a> {
     pub fn matches(&self, other: &Origin) -> bool {
-        // if no scheme is specified allow all schemes
-        // if a scheme is specified they have to match
-        if self.scheme.is_some() && other.scheme.is_some() && self.scheme != other.scheme {
-            return false;
-        }
-
-        if self.port != other.port {
-            return false;
-        }
-
-        if self.hostname_parts.len() != other.hostname_parts.len() {
-            return false;
-        }
-
-        for (&this, &other) in zip(&self.hostname_parts, &other.hostname_parts) {
-            if this == WILDCARD {
-                continue;
-            }
-
-            if this != other {
-                return false;
-            }
-        }
-
-        true
+        self.matches_internal(other, MatchDirection::Forward)
     }
 
-    pub fn matches_opt(&self, other: &Origin, policy: MatchingPolicy) -> bool {
-        if policy.contains(MatchingPolicy::CheckScheme) {
-            if policy.contains(MatchingPolicy::AllowEmptyScheme) {
-                if self.scheme.is_some() && other.scheme.is_some() && self.scheme != other.scheme {
-                    return false;
-                }
-            } else if self.scheme != other.scheme {
-                return false;
-            }
-        }
-
-        if policy.contains(MatchingPolicy::CheckPort) {
-            if policy.contains(MatchingPolicy::AllowEmptyPort) {
-                if self.port.is_some() && other.port.is_some() && self.port != other.port {
-                    return false;
-                }
-            } else if self.port != other.port {
-                return false;
-            }
-        }
-
-        if self.hostname_parts.len() != other.hostname_parts.len() {
-            return false;
-        }
-
-        let match_domain =
-            zip(&self.hostname_parts, &other.hostname_parts).fold(true, |res, (this, other)| {
-                if this == &WILDCARD {
-                    res
-                } else {
-                    res && this == other
-                }
-            });
-
-        let match_bundle_id = if policy.contains(MatchingPolicy::AllowBundleID) {
-            let x = &other.hostname_parts;
-            let ot = x.iter().rev();
-            let zip1: Zip<Iter<&str>, Rev<Iter<&str>>> = zip(&self.hostname_parts, ot);
-
-            zip1.fold(true, |res, (this, other)| {
-                if this == &WILDCARD {
-                    res
-                } else {
-                    res && this == other
-                }
-            })
-        } else {
-            false
-        };
-
-        match_domain || match_bundle_id
+    pub fn matches_rev(&self, other: &Origin) -> bool {
+        self.matches_internal(other, MatchDirection::Reverse)
     }
 
     pub fn hostname(&self) -> &str {
         self.hostname
+    }
+
+    fn matches_internal(&self, other: &Origin, dir: MatchDirection) -> bool {
+        if self.scheme.is_some() && other.scheme.is_some() && self.scheme != other.scheme {
+            return false;
+        }
+
+        if self.port.is_some() && other.port.is_some() && self.port != other.port {
+            return false;
+        }
+
+        if self.hostname_parts.len() != other.hostname_parts.len() {
+            return false;
+        }
+
+        match dir {
+            MatchDirection::Forward => {
+                zip(&self.hostname_parts, &other.hostname_parts).fold(true, match_fold_cb)
+            }
+
+            MatchDirection::Reverse => zip(&self.hostname_parts, other.hostname_parts.iter().rev())
+                .fold(true, match_fold_cb),
+        }
+    }
+}
+
+#[inline]
+fn match_fold_cb(res: bool, (this, other): (&&str, &&str)) -> bool {
+    if this == &WILDCARD {
+        res
+    } else {
+        res && this == other
     }
 }
 
@@ -202,10 +141,7 @@ impl<'a> Display for Origin<'a> {
 
 #[cfg(test)]
 mod test {
-    use {
-        super::{Origin, OriginParseError},
-        crate::project::MatchingPolicy,
-    };
+    use super::{Origin, OriginParseError};
 
     #[test]
     fn parse_origin() {
@@ -318,170 +254,136 @@ mod test {
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("domain.name").unwrap();
         let o2 = Origin::try_from("domain.name").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
 
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("domain.name:123").unwrap();
         let o2 = Origin::try_from("domain.name:124").unwrap();
 
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://domain.name:123").unwrap();
         let o2 = Origin::try_from("domain.name:124").unwrap();
 
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name/").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
 
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name/").unwrap();
         let o2 = Origin::try_from("a.b.domain.name").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("https://react-app.walletconnect.com").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
 
         // Allow trailing slash.
         let o1 = Origin::try_from("https://react-app.walletconnect.com/").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
 
         // Allow custom schema when it's unspecified.
         let o1 = Origin::try_from("custom-schema://react-app.walletconnect.com/").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(&o2, MatchingPolicy::default()));
+        assert!(o1.matches(&o2));
     }
 
     #[test]
     fn origin_matching_opt_scheme() {
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(&o2, MatchingPolicy::CheckScheme));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
-        let o2 = Origin::try_from("http://a.b.domain.name:456").unwrap();
-        assert!(o1.matches_opt(&o2, MatchingPolicy::CheckScheme));
+        let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("https://a.b.domain.name:123").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckScheme));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckScheme));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("a.b.domain.name:123").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckScheme));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckScheme | MatchingPolicy::AllowEmptyScheme
-        ));
-
-        let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
-        let o2 = Origin::try_from("http://a.b.domain.name:456").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckScheme | MatchingPolicy::AllowEmptyScheme
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("https://a.b.domain.name:123").unwrap();
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckScheme | MatchingPolicy::AllowEmptyScheme
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckScheme | MatchingPolicy::AllowEmptyScheme
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckScheme | MatchingPolicy::AllowEmptyScheme
-        ));
+        assert!(o1.matches(&o2));
     }
 
     #[test]
     fn origin_matching_opt_port() {
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(&o2, MatchingPolicy::CheckPort));
+        assert!(o1.matches(&o2));
 
-        let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
+        let o1 = Origin::try_from("https://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("https://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(&o2, MatchingPolicy::CheckPort));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:456").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckPort));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckPort));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
-        assert!(!o1.matches_opt(&o2, MatchingPolicy::CheckPort));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckPort | MatchingPolicy::AllowEmptyPort
-        ));
+        assert!(o1.matches(&o2));
 
-        let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
+        let o1 = Origin::try_from("https://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("https://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckPort | MatchingPolicy::AllowEmptyPort
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:456").unwrap();
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckPort | MatchingPolicy::AllowEmptyPort
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckPort | MatchingPolicy::AllowEmptyPort
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::CheckPort | MatchingPolicy::AllowEmptyPort
-        ));
+        assert!(o1.matches(&o2));
     }
 
     #[test]
@@ -489,107 +391,68 @@ mod test {
         let o1 = Origin::try_from("http://a.*.domain.name:123").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name:123").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("domain.name").unwrap();
         let o2 = Origin::try_from("domain.name").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
 
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("domain.name:123").unwrap();
         let o2 = Origin::try_from("domain.name:124").unwrap();
 
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://domain.name:123").unwrap();
         let o2 = Origin::try_from("domain.name:124").unwrap();
 
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name/").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
 
-        assert!(!o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(!o1.matches(&o2));
 
         let o1 = Origin::try_from("https://a.b.domain.name/").unwrap();
         let o2 = Origin::try_from("a.b.domain.name").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("https://react-app.walletconnect.com").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         // Allow trailing slash.
         let o1 = Origin::try_from("https://react-app.walletconnect.com/").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         // Allow custom schema when it's unspecified.
         let o1 = Origin::try_from("custom-schema://react-app.walletconnect.com/").unwrap();
         let o2 = Origin::try_from("react-app.walletconnect.com").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://a.b.domain.name").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("http://name.domain.b.a").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches_rev(&o2));
 
         let o1 = Origin::try_from("http://a.b.domain.name").unwrap();
         let o2 = Origin::try_from("name.domain.b.a").unwrap();
 
-        assert!(o1.matches_opt(
-            &o2,
-            MatchingPolicy::default() | MatchingPolicy::AllowBundleID
-        ));
+        assert!(o1.matches_rev(&o2));
     }
 }

--- a/src/project/types/origin.rs
+++ b/src/project/types/origin.rs
@@ -2,7 +2,6 @@ use {
     once_cell::sync::Lazy,
     regex::Regex,
     std::{fmt::Display, iter::zip},
-    thiserror::Error as ThisError,
 };
 
 /// Simplified URL parser regex. Extracts only the scheme (optional), hostname
@@ -72,7 +71,7 @@ fn match_fold_cb(res: bool, (this, other): (&&str, &&str)) -> bool {
     }
 }
 
-#[derive(Debug, ThisError, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum OriginParseError {
     #[error("invalid origin format")]
     InvalidFormat,

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -47,8 +47,7 @@ impl ProjectData {
     pub fn validate_access(
         &self,
         id: &str,
-        origin: Option<&str>,
-        source: OriginSource,
+        origin: Option<(&str, OriginSource)>,
     ) -> Result<(), AccessError> {
         // Make sure the project is not disabled globally.
         if !self.is_enabled {
@@ -61,7 +60,7 @@ impl ProjectData {
             .position(|key| key.value == id && key.is_valid)
             .ok_or(AccessError::KeyInvalid)?;
 
-        if let Some(origin) = origin {
+        if let Some((origin, source)) = origin {
             let origin = Origin::try_from(origin).map_err(|_| AccessError::OriginNotAllowed)?;
 
             match source {
@@ -172,69 +171,69 @@ mod test {
         };
 
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::Header)
+            .validate_access("test", Some(("invalid.host.com", OriginSource::Header)))
             .is_err());
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::BundleId)
+            .validate_access("test", Some(("invalid.host.com", OriginSource::BundleId)))
             .is_err());
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::PackageName)
+            .validate_access(
+                "test",
+                Some(("invalid.host.com", OriginSource::PackageName))
+            )
             .is_err());
 
         assert!(project
             .validate_access(
                 "test",
-                Some("prod.header.example.com"),
-                OriginSource::Header
+                Some(("prod.header.example.com", OriginSource::Header)),
             )
             .is_ok());
         assert!(project
             .validate_access(
                 "test",
-                Some("com.example.header.prod"),
-                OriginSource::Header
+                Some(("com.example.header.prod", OriginSource::Header)),
             )
             .is_ok());
         assert!(project
             .validate_access(
                 "test",
-                Some("prod.header.example.com"),
-                OriginSource::BundleId
+                Some(("prod.header.example.com", OriginSource::BundleId)),
             )
             .is_err());
         assert!(project
             .validate_access(
                 "test",
-                Some("prod.header.example.com"),
-                OriginSource::PackageName
+                Some(("prod.header.example.com", OriginSource::PackageName)),
             )
             .is_err());
 
         assert!(project
-            .validate_access("test", Some("com.example.bundle"), OriginSource::Header)
+            .validate_access("test", Some(("com.example.bundle", OriginSource::Header)))
             .is_err());
         assert!(project
-            .validate_access("test", Some("com.example.bundle"), OriginSource::BundleId)
+            .validate_access("test", Some(("com.example.bundle", OriginSource::BundleId)))
             .is_ok());
         assert!(project
             .validate_access(
                 "test",
-                Some("com.example.bundle"),
-                OriginSource::PackageName
+                Some(("com.example.bundle", OriginSource::PackageName))
             )
             .is_err());
 
         assert!(project
-            .validate_access("test", Some("com.example.package"), OriginSource::Header)
-            .is_err());
-        assert!(project
-            .validate_access("test", Some("com.example.package"), OriginSource::BundleId)
+            .validate_access("test", Some(("com.example.package", OriginSource::Header)))
             .is_err());
         assert!(project
             .validate_access(
                 "test",
-                Some("com.example.package"),
-                OriginSource::PackageName
+                Some(("com.example.package", OriginSource::BundleId))
+            )
+            .is_err());
+        assert!(project
+            .validate_access(
+                "test",
+                Some(("com.example.package", OriginSource::PackageName)),
             )
             .is_ok());
 
@@ -262,13 +261,16 @@ mod test {
         };
 
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::Header)
+            .validate_access("test", Some(("invalid.host.com", OriginSource::Header)))
             .is_ok());
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::BundleId)
+            .validate_access("test", Some(("invalid.host.com", OriginSource::BundleId)))
             .is_ok());
         assert!(project
-            .validate_access("test", Some("invalid.host.com"), OriginSource::PackageName)
+            .validate_access(
+                "test",
+                Some(("invalid.host.com", OriginSource::PackageName))
+            )
             .is_ok());
     }
 }

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -66,7 +66,7 @@ impl ProjectData {
                 Origin::try_from(auth_origin).map_err(|_| AccessError::OriginNotAllowed)?;
 
             match source {
-                OriginSource::Header => self.valiadte_origin_header(&auth_origin, true),
+                OriginSource::Header => self.validate_origin_header(&auth_origin, true),
                 OriginSource::BundleId => self.validate_origin(&auth_origin, &self.bundle_ids),
                 OriginSource::PackageName => {
                     self.validate_origin(&auth_origin, &self.package_names)
@@ -78,7 +78,7 @@ impl ProjectData {
         }
     }
 
-    fn valiadte_origin_header(
+    fn validate_origin_header(
         &self,
         auth_origin: &Origin<'_>,
         allow_empty: bool,
@@ -136,7 +136,7 @@ impl ProjectData {
 
         // If we couldn't match, fallback to matching against `allowed_origins` list for
         // backwards compatibility.
-        self.valiadte_origin_header(auth_origin, false)
+        self.validate_origin_header(auth_origin, false)
     }
 }
 

--- a/src/project/types/project_data.rs
+++ b/src/project/types/project_data.rs
@@ -1,7 +1,14 @@
 use {
-    crate::project::{error::AccessError, MatchingPolicy, Origin},
+    crate::project::{error::AccessError, Origin},
     serde::{Deserialize, Serialize},
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OriginSource {
+    Header,
+    BundleId,
+    PackageName,
+}
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -23,6 +30,8 @@ pub struct ProjectData {
     pub is_rate_limited: bool,
     pub allowed_origins: Vec<String>,
     pub verified_domains: Vec<String>,
+    pub bundle_ids: Vec<String>,
+    pub package_names: Vec<String>,
     pub quota: Quota,
 }
 
@@ -35,15 +44,11 @@ pub struct Quota {
 }
 
 impl ProjectData {
-    pub fn validate_access(&self, id: &str, auth_origin: Option<&str>) -> Result<(), AccessError> {
-        self.validate_access_opt(id, auth_origin, MatchingPolicy::default())
-    }
-
-    pub fn validate_access_opt(
+    pub fn validate_access(
         &self,
         id: &str,
         auth_origin: Option<&str>,
-        matching_policy: MatchingPolicy,
+        source: OriginSource,
     ) -> Result<(), AccessError> {
         // Make sure the project is not disabled globally.
         if !self.is_enabled {
@@ -56,39 +61,309 @@ impl ProjectData {
             .position(|key| key.value == id && key.is_valid)
             .ok_or(AccessError::KeyInvalid)?;
 
-        // Allow all origins if the list is empty.
-        if self.allowed_origins.is_empty() {
-            return Ok(());
-        }
-
         if let Some(auth_origin) = auth_origin {
             let auth_origin =
                 Origin::try_from(auth_origin).map_err(|_| AccessError::OriginNotAllowed)?;
-            let auth_origin_host = auth_origin.hostname();
 
-            const ALLOWED_LOCAL_HOSTS: [&str; 2] = ["localhost", "127.0.0.1"];
-
-            for host in ALLOWED_LOCAL_HOSTS {
-                if auth_origin_host == host {
-                    return Ok(());
+            match source {
+                OriginSource::Header => self.valiadte_origin_header(&auth_origin, true),
+                OriginSource::BundleId => self.validate_origin(&auth_origin, &self.bundle_ids),
+                OriginSource::PackageName => {
+                    self.validate_origin(&auth_origin, &self.package_names)
                 }
             }
-
-            for origin in &self.allowed_origins {
-                // Having a malformed entry in the allow list is okay. We'll just ignore it.
-                if let Ok(origin) = Origin::try_from(origin.as_str()) {
-                    if origin.matches_opt(&auth_origin, matching_policy) {
-                        // Found a match, grant access.
-                        return Ok(());
-                    }
-                }
-            }
-
-            // Origin did not match the allow list. Deny access.
-            Err(AccessError::OriginNotAllowed)
         } else {
             // Origin was not provided. Grant access.
             Ok(())
         }
+    }
+
+    fn valiadte_origin_header(
+        &self,
+        auth_origin: &Origin<'_>,
+        allow_empty: bool,
+    ) -> Result<(), AccessError> {
+        if allow_empty && self.allowed_origins.is_empty() {
+            // Allow all origins if the list is empty.
+            return Ok(());
+        }
+
+        const ALLOWED_LOCAL_HOSTS: [&str; 2] = ["localhost", "127.0.0.1"];
+
+        let auth_origin_host = auth_origin.hostname();
+
+        for host in ALLOWED_LOCAL_HOSTS {
+            if auth_origin_host == host {
+                return Ok(());
+            }
+        }
+
+        for origin in &self.allowed_origins {
+            // Ignore malformed entries.
+            let Ok(origin) = Origin::try_from(origin.as_str()) else {
+                continue;
+            };
+
+            // Support both forward and reverse matching here for backwards compatibility.
+            if origin.matches(auth_origin) || origin.matches_rev(auth_origin) {
+                return Ok(());
+            }
+        }
+
+        Err(AccessError::OriginNotAllowed)
+    }
+
+    fn validate_origin(
+        &self,
+        auth_origin: &Origin<'_>,
+        allow_list: &[String],
+    ) -> Result<(), AccessError> {
+        // Allow all origins if the list is empty.
+        if allow_list.is_empty() {
+            return Ok(());
+        }
+
+        for origin in allow_list {
+            // Ignore malformed entries.
+            let Ok(origin) = Origin::try_from(origin.as_str()) else {
+                continue;
+            };
+
+            if origin.matches(auth_origin) {
+                return Ok(());
+            }
+        }
+
+        // If we couldn't match, fallback to matching against `allowed_origins` list for
+        // backwards compatibility.
+        self.valiadte_origin_header(auth_origin, false)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn origin_validation() {
+        let project = ProjectData {
+            uuid: "test".to_owned(),
+            creator: "test".to_owned(),
+            push_url: None,
+            name: "test".to_owned(),
+            keys: vec![ProjectKey {
+                value: "test".to_owned(),
+                is_valid: true,
+            }],
+            verified_domains: vec![],
+            is_rate_limited: true,
+            is_verify_enabled: false,
+            allowed_origins: vec![
+                "https://*.example.com".to_owned(),
+                "https://prod.bundle.example.com".to_owned(),
+                "https://prod.package.example.com".to_owned(),
+            ],
+            is_enabled: true,
+            quota: Quota {
+                max: 100000000,
+                current: 0,
+                is_valid: true,
+            },
+            bundle_ids: vec![
+                "com.example.bundle".to_owned(),
+                "com.example.bundle.dev".to_owned(),
+                "com.example.bundle.staging".to_owned(),
+            ],
+            package_names: vec![
+                "com.example.package".to_owned(),
+                "com.example.package.dev".to_owned(),
+                "com.example.package.staging".to_owned(),
+            ],
+        };
+
+        assert!(project
+            .validate_access("test", Some("invalid.host.com"), OriginSource::Header)
+            .is_err());
+
+        assert!(project
+            .validate_access(
+                "test",
+                Some("prod.bundle.example.com"),
+                OriginSource::Header
+            )
+            .is_ok());
+
+        assert!(project
+            .validate_access("test", Some("dev.bundle.example.com"), OriginSource::Header)
+            .is_err());
+
+        assert!(project
+            .validate_access("test", Some("test.example.com"), OriginSource::Header)
+            .is_ok());
+
+        // Allowed because `allowed_origins` is used as a fallback.
+        assert!(project
+            .validate_access("test", Some("test.example.com"), OriginSource::BundleId)
+            .is_ok());
+
+        // Allowed because `allowed_origins` is used as a fallback, and matched in
+        // reverse as bundle ID.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.bundle.prod"),
+                OriginSource::BundleId
+            )
+            .is_ok());
+
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.bundle.dev"),
+                OriginSource::BundleId
+            )
+            .is_ok());
+
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.package.dev"),
+                OriginSource::BundleId
+            )
+            .is_err());
+
+        // Allowed because `allowed_origins` is used as a fallback.
+        assert!(project
+            .validate_access("test", Some("test.example.com"), OriginSource::PackageName)
+            .is_ok());
+
+        // Allowed because `allowed_origins` is used as a fallback, and matched in
+        // reverse as bundle ID.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.package.prod"),
+                OriginSource::PackageName
+            )
+            .is_ok());
+
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.package.dev"),
+                OriginSource::PackageName
+            )
+            .is_ok());
+
+        assert!(project
+            .validate_access(
+                "test",
+                Some("com.example.bundle.dev"),
+                OriginSource::PackageName
+            )
+            .is_err());
+
+        let project = ProjectData {
+            uuid: "test".to_owned(),
+            creator: "test".to_owned(),
+            push_url: None,
+            name: "test".to_owned(),
+            keys: vec![ProjectKey {
+                value: "test".to_owned(),
+                is_valid: true,
+            }],
+            verified_domains: vec![],
+            is_rate_limited: true,
+            is_verify_enabled: false,
+            allowed_origins: vec![],
+            is_enabled: true,
+            quota: Quota {
+                max: 100000000,
+                current: 0,
+                is_valid: true,
+            },
+            bundle_ids: vec![
+                "com.example.bundle".to_owned(),
+                "com.example.bundle.dev".to_owned(),
+                "com.example.bundle.staging".to_owned(),
+            ],
+            package_names: vec![
+                "com.example.package".to_owned(),
+                "com.example.package.dev".to_owned(),
+                "com.example.package.staging".to_owned(),
+            ],
+        };
+
+        // Allowed because `allowed_origins` list is empty.
+        assert!(project
+            .validate_access("test", Some("dev.bundle.example.com"), OriginSource::Header)
+            .is_ok());
+
+        // Not allowed because `bundle_ids` list is not empty.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("test.bundle.example.com"),
+                OriginSource::BundleId
+            )
+            .is_err());
+
+        // Not allowed because `package_names` list is not empty.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("test.package.example.com"),
+                OriginSource::PackageName
+            )
+            .is_err());
+
+        let project = ProjectData {
+            uuid: "test".to_owned(),
+            creator: "test".to_owned(),
+            push_url: None,
+            name: "test".to_owned(),
+            keys: vec![ProjectKey {
+                value: "test".to_owned(),
+                is_valid: true,
+            }],
+            verified_domains: vec![],
+            is_rate_limited: true,
+            is_verify_enabled: false,
+            allowed_origins: vec![
+                "https://*.example.com".to_owned(),
+                "https://prod.bundle.example.com".to_owned(),
+                "https://prod.package.example.com".to_owned(),
+            ],
+            is_enabled: true,
+            quota: Quota {
+                max: 100000000,
+                current: 0,
+                is_valid: true,
+            },
+            bundle_ids: vec![],
+            package_names: vec![],
+        };
+
+        assert!(project
+            .validate_access("test", Some("dev.bundle.example.com"), OriginSource::Header)
+            .is_err());
+
+        // Allowed because `bundle_ids` list is empty.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("dev.bundle.example.com"),
+                OriginSource::BundleId
+            )
+            .is_ok());
+
+        // Allowed because `package_names` list is empty.
+        assert!(project
+            .validate_access(
+                "test",
+                Some("dev.package.example.com"),
+                OriginSource::PackageName
+            )
+            .is_ok());
     }
 }

--- a/src/registry/client.rs
+++ b/src/registry/client.rs
@@ -154,6 +154,8 @@ mod test {
             is_rate_limited: false,
             allowed_origins: vec![],
             verified_domains: vec![],
+            bundle_ids: vec![],
+            package_names: vec![],
             quota: project::Quota {
                 max: 42,
                 current: 1,


### PR DESCRIPTION
# Description

This implements validation against `bundle_ids` and `package_names` lists.

As per [discussion](https://walletconnect.slack.com/archives/C03S6NT5VS5/p1713777250373059) there's now separate validation methods for different sources of `origin` param.

## How Has This Been Tested?

Existing and new tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
