### PR TITLE
fix: return Ok(None) when project not found in project_data_with

### DIFF
--- a/src/registry/client.rs
+++ b/src/registry/client.rs
@@ -289,11 +289,16 @@ impl RegistryHttpClient {
         if !is_valid_project_id(request.id) {
             return Ok(None);
         }
-        // Always fetch the base project data
-        let data = self
-            .project_data(request.id)
-            .await?
-            .ok_or_else(|| RegistryError::Response("Project not found".to_string()))?;
+        // Always fetch the base project data. A missing project (registry
+        // returns 404) must surface as `Ok(None)` so callers can tell
+        // "project not found" apart from a transient registry error, matching
+        // the behaviour of `project_data_with_limits_impl`. Returning an `Err`
+        // here causes callers to treat an unknown project as a registry outage
+        // and fail open.
+        let data = match self.project_data(request.id).await? {
+            Some(data) => data,
+            None => return Ok(None),
+        };
 
         let limits = match request.include_limits {
             true => Some(
@@ -528,6 +533,41 @@ mod test {
             .project_data(&project_id)
             .await
             .unwrap();
+        assert!(response.is_none());
+    }
+
+    #[tokio::test]
+    async fn project_data_with_returns_none_when_project_not_found() {
+        let project_id = "a".repeat(32);
+
+        let mock_server = MockServer::start().await;
+
+        // Registry returns 404 for a well-formed but unregistered project id.
+        Mock::given(method(Method::Get))
+            .and(path(format!("/internal/project/key/{project_id}")))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+
+        let request = crate::project::ProjectDataRequest::new(&project_id).include_limits();
+
+        let response = RegistryHttpClient::with_config(
+            mock_server.uri(),
+            Some(mock_server.uri()),
+            "auth",
+            TEST_ORIGIN,
+            "st",
+            "sv",
+            Default::default(),
+        )
+        .unwrap()
+        .project_data_with(request)
+        .await
+        .unwrap();
+
+        // A missing project must be `Ok(None)`, not an `Err`: an `Err` makes
+        // callers treat an unknown project as a transient registry outage and
+        // fail open instead of rejecting the request.
         assert!(response.is_none());
     }
 


### PR DESCRIPTION
## Summary

`project_data_with_impl` mapped a registry **404 (project not found)** to
`Err(RegistryError::Response("Project not found"))` instead of `Ok(None)`.
This is inconsistent with `project_data_with_limits_impl`, which correctly
returns `Ok(None)` when the base project lookup misses.

## Why this matters

Callers can't tell "project doesn't exist" apart from "registry had a transient
problem" — both arrive as `Err`. Services that fail open on transient registry
errors therefore let **any well-formed-but-unregistered project ID** through.

Concretely in blockchain-api:
- `project_data_internal` treats any non-`Config` `RegistryError` as a transient
  outage → opens its circuit breaker → returns `RegistryTemporarilyUnavailable`.
- `validate_project_access[_and_quota]` treats `RegistryTemporarilyUnavailable`
  as "skip the check" (fail open).

Net effect: a 32-hex project ID that isn't registered (e.g.
`00000000000000000000000000000000`) bypasses project access + quota validation
entirely. Only malformed IDs (wrong length / non-hex) get rejected, since those
are caught earlier by `is_valid_project_id`.

## Fix

Return `Ok(None)` when the base project-data lookup returns `None` (registry
404), matching `project_data_with_limits_impl`. Callers can then treat it as
"not found" and reject, instead of failing open.

## Test

Adds `project_data_with_returns_none_when_project_not_found`: mocks a 404 on the
project-data endpoint and asserts `project_data_with(...)` returns `Ok(None)`.